### PR TITLE
fix(ci): combine release and publish into single job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     concurrency: release
-    outputs:
-      released: ${{ steps.release.outputs.released }}
-      version: ${{ steps.release.outputs.version }}
+    environment:
+      name: pypi
+      url: https://pypi.org/project/gt-telem/
 
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +30,10 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install Python Semantic Release
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install python-semantic-release
+          pip install python-semantic-release build twine
 
       - name: Python Semantic Release
         id: release
@@ -42,52 +42,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-
-          # Run semantic-release version and capture output
-          OUTPUT=$(semantic-release version --print 2>&1) || true
-
-          # Check if a new version was created
-          if semantic-release version 2>&1 | grep -q "No release will be made"; then
-            echo "released=false" >> $GITHUB_OUTPUT
-            echo "No release needed"
-          else
-            VERSION=$(semantic-release version --print-last-released 2>/dev/null || echo "")
-            if [ -n "$VERSION" ]; then
-              echo "released=true" >> $GITHUB_OUTPUT
-              echo "version=$VERSION" >> $GITHUB_OUTPUT
-              echo "Released version: $VERSION"
-              semantic-release publish
-            else
-              echo "released=false" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    environment:
-      name: pypi
-      url: https://pypi.org/project/gt-telem/
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main  # Ensure we get the updated version
-
-      - name: Pull latest changes
-        run: git pull origin main
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine
+          semantic-release version
 
       - name: Build package
         run: python -m build
@@ -97,3 +52,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ match = "main"
 prerelease = false
 
 [tool.semantic_release.changelog]
-changelog_file = "CHANGELOG.md"
+default_templates.changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = [
     "^chore\\(release\\):",
     "^ci:",


### PR DESCRIPTION
## Changes
- Combine release and publish into a single job so the build happens in the same checkout after `semantic-release version` bumps the files
- Fix changelog config deprecation warning (`changelog_file` → `default_templates.changelog_file`)

## Root cause
The previous workflow had two separate jobs. The publish job checked out `main` at the original commit SHA, so `python -m build` built version 1.2.0 instead of 1.2.1 even though the release job had already bumped the version.

## Fix
Everything now runs in one job in sequence:
1. `semantic-release version` — bumps version in files, commits, creates tag
2. `python -m build` — builds the package with the bumped version
3. `twine check` — validates the package
4. `pypa/gh-action-pypi-publish` — uploads to PyPI
5. `semantic-release publish` — creates the GitHub Release